### PR TITLE
[Docs] Add token addresses

### DIFF
--- a/docs/src/docs/parameters.mdx
+++ b/docs/src/docs/parameters.mdx
@@ -12,11 +12,11 @@ We aim to make new versions backwards compatible with our `IInvoker` interface. 
 ### Liquidity source ordering
 For the time being, the liquidity source priority order is set/updated by the protocol administrator. We aim to give higher priority to pools with larger liquidity and lower native fees. The current priority list is:
 
-| Asset     | 1st Priority     | 2nd Priority     |
-|-----------|------------------|------------------|
-| ETH       | Solo (DyDx)      | Aave             |
-| USDC      | Solo (DyDx)      | Aave             |
-| DAI       | Solo (DyDx)      | Aave             |
+| Asset     | Address                                    | 1st Priority     | 2nd Priority     |
+|-----------|--------------------------------------------|------------------|------------------|
+| ETH       | 0x0000000000000000000000000000000000000001 | Solo (DyDx)      | Aave             |
+| USDC      | 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 | Solo (DyDx)      | Aave             |
+| DAI       | 0x6b175474e89094c44da98b954eedeac495271d0f | Solo (DyDx)      | Aave             |
 
-### Kollateral Reward
+### Kollateral Fee
 Currently Kollateral charges an additional `6bps` fee on the liquidity that is sourced (on top of each pool's native fee if applicable). All repayment calculation is handled by Kollateral and surfaced to your invokable contract via the `KollateralInvokable` helpers such as `repay()`.


### PR DESCRIPTION
- Adds token addresses that are supported (especially denoting ETH's kollateral address).
- Make fee section more clear.